### PR TITLE
Anonymous login, new SearchClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.5'
 - '3.6'
 install:
-- pip install pip --upgrade --no-cache-dir
+- pip install pip>=9.* --upgrade --no-cache-dir
 - pip install -e .
 - pip install pytest pytest-cov coveralls flake8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: python
 python:
 - '2.7'
-- '3.3'
+#- '3.3'  # Bug in TravisCI prevents 3.3 tests running (old pip in path)
 - '3.4'
 - '3.5'
 - '3.6'
 install:
-- pip install --upgrade pip
 - pip install -e .
 - pip install pytest pytest-cov coveralls flake8
 env:
 - TEST_ENV=travis
-sudo: required
 script:
 - flake8 . && travis_wait 50 py.test
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.5'
 - '3.6'
 install:
-- pip install pip --upgrade --no-cache-dir --user
+- pip install pip --upgrade --no-cache-dir
 - pip install -e .
 - pip install pytest pytest-cov coveralls flake8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.5'
 - '3.6'
 install:
-- pip install --upgrade pip
+- pip install pip --upgrade --no-cache-dir --user
 - pip install -e .
 - pip install pytest pytest-cov coveralls flake8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ python:
 - '3.5'
 - '3.6'
 install:
-- pip install pip>=9.* --upgrade --no-cache-dir
+- pip install --upgrade pip
 - pip install -e .
 - pip install pytest pytest-cov coveralls flake8
 env:
 - TEST_ENV=travis
+sudo: required
 script:
 - flake8 . && travis_wait 50 py.test
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - '3.5'
 - '3.6'
 install:
+- pip install --upgrade pip
 - pip install -e .
 - pip install pytest pytest-cov coveralls flake8
 env:

--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -154,7 +154,7 @@ def login(credentials=None, clear_old_tokens=False, **kwargs):
                                  + "'.")
 
     native_client = globus_sdk.NativeAppAuthClient(creds.get("client_id", NATIVE_CLIENT_ID),
-                                                    app_name=creds.get("app_name", "unknown"))
+                                                   app_name=creds.get("app_name", "unknown"))
 
     servs = []
     for serv in creds.get("services", []):

--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -153,8 +153,8 @@ def login(credentials=None, clear_old_tokens=False, **kwargs):
                                  + DEFAULT_CRED_PATH
                                  + "'.")
 
-    native_client = (globus_sdk.NativeAppAuthClient(creds.get("client_id", NATIVE_CLIENT_ID),
-                                                    app_name=creds.get("app_name", "unknown")))
+    native_client = globus_sdk.NativeAppAuthClient(creds.get("client_id", NATIVE_CLIENT_ID),
+                                                    app_name=creds.get("app_name", "unknown"))
 
     servs = []
     for serv in creds.get("services", []):
@@ -238,9 +238,7 @@ def login(credentials=None, clear_old_tokens=False, **kwargs):
     if "publish" in servs:
         try:
             publish_authorizer = globus_sdk.RefreshTokenAuthorizer(
-                                        all_tokens[("https://auth.globus.org/scopes"
-                                                    "/ab24b500-37a2-4bad-ab66-d8232c18e6e5"
-                                                    "/publish_api")]["refresh_token"],
+                                        all_tokens["publish.api.globus.org"]["refresh_token"],
                                         native_client)
             clients["publish"] = DataPublicationClient(authorizer=publish_authorizer)
         # Token not present

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup
 
 setup(
     name='mdf_toolbox',
-    version='0.1.3',
+    version='0.1.4',
     packages=['mdf_toolbox'],
     description='Materials Data Facility Python utilities',
     long_description=("Toolbox is the Materials Data Facility Python package"
                       " containing utility functions and other tools."),
     install_requires=[
-        "globus-sdk>=1.2.1",
+        "globus-sdk>=1.4.1",
         "requests>=2.18.4",
         "tqdm>=4.19.4",
         "six>=1.11.0"

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -13,7 +13,7 @@ credentials = {
     }
 
 
-def test_login():
+def test_login(capsys):
     # Login works
     creds1 = deepcopy(credentials)
     creds1["services"] = ["search"]
@@ -39,12 +39,44 @@ def test_login():
     with pytest.raises(ValueError):
         toolbox.login()
 
+    # Error on bad services
+    creds4 = deepcopy(credentials)
+    creds4["services"] = ["garbage", "invalid"]
+    assert toolbox.login(creds4) == {}
+    out, err = capsys.readouterr()
+    assert "Unknown or invalid service: 'garbage'." in out
+    assert "Unknown or invalid service: 'invalid'." in out
+
     # TODO: Test user input prompt
 
 
 def test_confidential_login():
     # TODO
     pass
+
+
+def test_anonymous_login(capsys):
+    # Valid services work
+    res1 = toolbox.anonymous_login(["transfer", "search", "publish"])
+    assert isinstance(res1.get("search"), toolbox.SearchClient)
+    assert isinstance(res1.get("transfer"), globus_sdk.TransferClient)
+    assert isinstance(res1.get("publish"), toolbox.DataPublicationClient)
+
+    # Single service works
+    res2 = toolbox.anonymous_login("search")
+    assert isinstance(res2.get("search"), toolbox.SearchClient)
+
+    # Auth-only services don't work
+    assert toolbox.anonymous_login(["search_ingest", "mdf"]) == {}
+    out, err = capsys.readouterr()
+    assert "Error: Service 'search_ingest' requires authentication." in out
+    assert "Error: Service 'mdf' requires authentication." in out
+
+    # Bad services don't work
+    assert toolbox.anonymous_login(["garbage", "invalid"]) == {}
+    out, err = capsys.readouterr()
+    assert "Unknown or invalid service: 'garbage'." in out
+    assert "Unknown or invalid service: 'invalid'." in out
 
 
 def test_find_files():

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -8,8 +8,7 @@ from mdf_toolbox import toolbox
 
 credentials = {
     "app_name": "MDF_Forge",
-    "services": [],
-    "index": "mdf-test"
+    "services": []
     }
 
 
@@ -19,13 +18,13 @@ def test_login(capsys):
     creds1["services"] = ["search"]
     res1 = toolbox.login(creds1)
     assert type(res1) is dict
-    assert isinstance(res1.get("search"), toolbox.SearchClient)
+    assert isinstance(res1.get("search"), globus_sdk.SearchClient)
 
     # Test other services
     creds2 = deepcopy(credentials)
     creds2["services"] = ["search_ingest", "mdf", "transfer"]
     res2 = toolbox.login(creds2)
-    assert isinstance(res2.get("search_ingest"), toolbox.SearchClient)
+    assert isinstance(res2.get("search_ingest"), globus_sdk.SearchClient)
     assert isinstance(res2.get("transfer"), globus_sdk.TransferClient)
     assert isinstance(res2.get("mdf"), globus_sdk.RefreshTokenAuthorizer)
 
@@ -58,13 +57,13 @@ def test_confidential_login():
 def test_anonymous_login(capsys):
     # Valid services work
     res1 = toolbox.anonymous_login(["transfer", "search", "publish"])
-    assert isinstance(res1.get("search"), toolbox.SearchClient)
+    assert isinstance(res1.get("search"), globus_sdk.SearchClient)
     assert isinstance(res1.get("transfer"), globus_sdk.TransferClient)
     assert isinstance(res1.get("publish"), toolbox.DataPublicationClient)
 
     # Single service works
     res2 = toolbox.anonymous_login("search")
-    assert isinstance(res2.get("search"), toolbox.SearchClient)
+    assert isinstance(res2.get("search"), globus_sdk.SearchClient)
 
     # Auth-only services don't work
     assert toolbox.anonymous_login(["search_ingest", "mdf"]) == {}
@@ -412,11 +411,6 @@ def test_dict_merge():
         toolbox.dict_merge({}, "a")
     with pytest.raises(TypeError):
         toolbox.dict_merge([], [])
-
-
-def test_SearchClient():
-    # TODO
-    pass
 
 
 def test_DataPublicationClient():


### PR DESCRIPTION
Add anonymous_login to allow initialization of clients without Globus Auth authentication. Most useful for Search, but Publish and Transfer will initialize as well. Search (ingest) and the MDF authorizer will fail to init anonymously. Also update the globus_sdk to the latest version, where the SearchClient is integrated and will be maintained. Toolbox no longer needs to keep and maintain the SearchClient class. Additional bugfixes, including a workaround for TravisCI having an outdated pip version at the front of their Python path (Python 3.3 is not tested on Travis for the time being, but Toolbox is still compatible).