### PR TITLE
Directory flexibility in custom_transfer

### DIFF
--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -617,7 +617,7 @@ def custom_transfer(transfer_client, source_ep, dest_ep, path_list,
         # Check if dest path is directory
         dest_exists = False
         try:
-            transfer_client.operation_ls(dest_ep, item[1])
+            transfer_client.operation_ls(dest_ep, path=item[1])
             dest_exists = True
             dest_is_dir = True
         except globus_sdk.exc.TransferAPIError as e:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mdf_toolbox',
-    version='0.3.1',
+    version='0.3.2',
     packages=['mdf_toolbox'],
     description='Materials Data Facility Python utilities',
     long_description=("Toolbox is the Materials Data Facility Python package"


### PR DESCRIPTION
`custom_transfer()` will now check if paths to transfer are directories manually. Globus Transfer requires this knowledge before a transfer can be started, and previously `custom_transfer()` passed the responsibility to the user, by requiring directories to have a trailing `/`. The trailing slash is no longer required. (It is still an error to have a trailing slash after a file name, as that is nonstandard.)