### PR TITLE
SearchHelper class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 - mv MDF_Forge_tokens.json ~/.mdf/credentials/MDF_Forge_tokens.json
 - mv MDF_Connect_Client_tokens.json ~/.mdf/credentials/MDF_Connect_Client_tokens.json
 - mv client_credentials.json ~/.mdf/credentials/client_credentials.json
+- cp ~/.mdf/credentials/MDF_Forge_tokens.json ~/.mdf/credentials/SearchHelper_Client_tokens.json
 after_success:
 - coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- '3.7'
+# - '3.7'  # Unsupported on Travis
 install:
 - pip install --upgrade pip
 - pip install -e .

--- a/mdf_toolbox/__init__.py
+++ b/mdf_toolbox/__init__.py
@@ -1,1 +1,5 @@
+# F401: Imported but unused - needed for import convenience
+# F403: Star import - Don't need to enumerate all tools
 from .toolbox import *  # noqa: F401,F403
+from .search_helper import SearchHelper  # noqa: F401
+from .sub_helpers import *  # noqa: F401,F403

--- a/mdf_toolbox/search_helper.py
+++ b/mdf_toolbox/search_helper.py
@@ -1,0 +1,810 @@
+from copy import deepcopy
+import warnings
+
+import globus_sdk
+
+import mdf_toolbox
+
+
+# Maximum number of results per search allowed by Globus Search
+SEARCH_LIMIT = 10000
+
+# Maximum number of results to return when advanced=False
+NONADVANCED_LIMIT = 10
+
+# List of allowed operators
+OP_LIST = ["AND", "OR", "NOT"]
+
+# List of characters that should trigger automatic quotation marks
+QUOTE_LIST = [" ", "\t", "\n", "'"]
+# List of characters that should disable automatic quotation marks
+# ex. range queries
+UNQUOTE_LIST = ["[", "]", "{", "}"]
+
+# Initial blank query
+BLANK_QUERY = {
+    "q": "(",
+    "advanced": False,
+    "limit": None,  # This is modified in _validate_query if not set
+    "offset": 0,
+    "facets": [],
+    "filters": [],
+    "sort": []
+}
+
+
+# ***********************************************
+# * Static internal utility functions
+# ***********************************************
+
+def _clean_query_string(q):
+    """Clean up a query string for searching.
+
+    Removes unmatched parentheses and joining operators.
+
+    Arguments:
+        q (str): Query string to be cleaned
+
+    Returns:
+        str: The clean query string.
+    """
+    q = q.replace("()", "").strip()
+    if q.endswith("("):
+        q = q[:-1].strip()
+    # Remove misplaced AND/OR/NOT at end
+    if q[-3:] == "AND" or q[-3:] == "NOT":
+        q = q[:-3]
+    elif q[-2:] == "OR":
+        q = q[:-2]
+
+    # Balance parentheses
+    while q.count("(") > q.count(")"):
+        q += ")"
+    while q.count(")") > q.count("("):
+        q = "(" + q
+
+    return q.strip()
+
+
+def _validate_query(query):
+    """Validate and clean up a query to be sent to Search.
+    Cleans the query string, removes unneeded parameters, and validates for correctness.
+    Does not modify the original argument.
+    Raises an Exception on invalid input.
+
+    Arguments:
+        query (dict): The query to validate.
+
+    Returns:
+        dict: The validated query.
+    """
+    query = deepcopy(query)
+    # q is always required
+    if query["q"] == BLANK_QUERY["q"]:
+        raise ValueError("No query specified.")
+
+    query["q"] = _clean_query_string(query["q"])
+
+    # limit should be set to appropriate default if not specified
+    if query["limit"] is None:
+        query["limit"] = SEARCH_LIMIT if query["advanced"] else NONADVANCED_LIMIT
+    # If specified, the limit should not be greater than the Search maximum
+    elif query["limit"] > SEARCH_LIMIT:
+        warnings.warn('Reduced result limit from {} to the Search maximum: {}'
+                      .format(query["limit"], SEARCH_LIMIT), RuntimeWarning)
+        query["limit"] = SEARCH_LIMIT
+
+    # Remove all blank/default values
+    for key, val in BLANK_QUERY.items():
+        # Default for get is NaN so comparison is always False
+        if query.get(key, float('nan')) == val:
+            query.pop(key)
+
+    # Remove unsupported fields
+    to_remove = [field for field in query.keys() if field not in BLANK_QUERY.keys()]
+    [query.pop(field) for field in to_remove]
+
+    return query
+
+
+# ****************************************************************************************
+# * SearchHelper
+# ****************************************************************************************
+
+class SearchHelper:
+    """Utility class for performing queries using a ``globus_sdk.SearchClient``.
+
+    Notes:
+        Query strings may end up wrapped in parentheses, which has no direct effect on the search.
+        It is inadvisable to use the "private" methods to modify the query string directly,
+        as the low-level logic for query string generation is not as user-friendly.
+    """
+    __app_name = "SearchHelper_Client"
+
+    def __init__(self, index, **kwargs):
+        """Create a SearchHelper object.
+
+        Arguments:
+            index (str): The Globus Search index to search on.
+
+        Keyword Arguments:
+            search_client (globus_sdk.SearchClient): The Globus Search client to use for
+                    searching. If not provided, one will be created and the user may be asked
+                    to log in. **Default**: ``None``.
+            anonymous (bool): If ``True``, will not authenticate with Globus Auth.
+                    If ``False``, will require authentication (either a SearchClient or
+                    a user-interactive login).
+                    **Default:** ``False``.
+
+                    Caution:
+                        Authentication is required to view non-public data in Search.
+                        An anonymous SearchHelper will only return public results.
+
+            app_name (str): The application name to use. Should be changed for
+                    subclassed clients, and left alone otherwise.
+                    Only used if performing login flow.
+                    **Default**: ``"SearchHelper_Client"``.
+            client_id (str): The ID of a native client to use when authenticating.
+                    Only used if performing login flow.
+                    **Default**: The ID of the MDF Native Clients native client.
+
+            q (str): A query string to initialize the SearchHelper with.
+                    Intended for internal use.
+            advanced (bool): The initial advanced state for thie SearchHelper.
+                    Intended for internal use.
+        """
+        if kwargs.get("search_client"):
+            self.__search_client = kwargs["search_client"]
+        elif kwargs.get("anonymous"):
+            self.__search_client = mdf_toolbox.anonymous_login(["search"])["search"]
+        else:
+            self.__search_client = mdf_toolbox.login(
+                                        app_name=kwargs.get("app_name", self.__app_name),
+                                        client_id=kwargs.get("client_id", None),
+                                        services=["search"])["search"]
+
+        # Get the UUID for the index if the name was provided
+        self.index = mdf_toolbox.translate_index(index)
+
+        # Query init
+        self.__query = deepcopy(BLANK_QUERY)
+        if kwargs.get("q"):
+            self.__query["q"] = kwargs["q"]
+        if kwargs.get("advanced"):
+            self.__query["advanced"] = kwargs["advanced"]
+
+    @property
+    def initialized(self):
+        """Whether any valid term has been added to the query."""
+        return bool(self._clean_query())
+
+    def logout(self):
+        """Delete Globus Auth tokens."""
+        mdf_toolbox.logout()
+
+    # ************************************************************************************
+    # * Internal functions
+    # ************************************************************************************
+
+    def _clean_query(self):
+        """Returns the current query, cleaned for user consumption.
+
+        Returns:
+            str: The clean current query.
+        """
+        return _clean_query_string(self.__query["q"])
+
+    def _term(self, term):
+        """Add a term to the query.
+
+        Arguments:
+            term (str): The term to add.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # All terms must be strings for Elasticsearch
+        term = str(term)
+        if term:
+            self.__query["q"] += term
+        return self
+
+    def _field(self, field, value):
+        """Add a ``field:value`` term to the query.
+        Matches will have the ``value`` in the ``field``.
+
+        Note:
+            This method triggers advanced mode.
+
+        Arguments:
+            field (str): The field to check for the value, in Elasticsearch dot syntax.
+            value (str): The value to match.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # Fields and values must be strings for Elasticsearch
+        field = str(field)
+        value = str(value)
+
+        # Check if quotes required and allowed, and quotes not present
+        # If the user adds improper double-quotes, this will not fix them
+        if (any([char in value for char in QUOTE_LIST]) and '"' not in value
+                and not any([char in value for char in UNQUOTE_LIST])):
+            value = '"' + value + '"'
+
+        # Cannot add field:value if one is blank
+        if field and value:
+            self.__query["q"] += field + ":" + value
+            # Field matches are advanced queries
+            self.__query["advanced"] = True
+
+        return self
+
+    def _operator(self, op, close_group=False):
+        """Add an operator between terms.
+        There must be a term added before using this method.
+        All operators have helpers, so this method is usually not necessary to directly invoke.
+
+        Arguments:
+            op (str): The operator to add. Must be in the OP_LIST.
+            close_group (bool): If ``True``, will end the current parenthetical
+                group and start a new one.
+                If ``False``, will continue current group.
+
+                Example::
+                    "(foo AND bar)" is one group.
+                    "(foo) AND (bar)" is two groups.
+
+        Returns:
+            SearchHelper: Self
+        """
+        op = op.upper().strip()
+        if op not in OP_LIST:
+            raise ValueError("Error: '{}' is not a valid operator.".format(op))
+        else:
+            if close_group:
+                op = ") " + op + " ("
+            else:
+                op = " " + op + " "
+            self.__query["q"] += op
+        return self
+
+    def _and_join(self, close_group=False):
+        """Combine terms with AND.
+        There must be a term added before using this method.
+
+        Arguments:
+            close_group (bool): If ``True``, will end the current group and start a new one.
+                    If ``False``, will continue current group.
+
+                    Example::
+
+                        If the current query is "(term1"
+                        .and(close_group=True) => "(term1) AND ("
+                        .and(close_group=False) => "(term1 AND "
+
+        Returns:
+            SearchHelper: Self
+        """
+        if not self.initialized:
+            raise ValueError("You must add a search term before adding an operator.")
+        else:
+            self._operator("AND", close_group=close_group)
+        return self
+
+    def _or_join(self, close_group=False):
+        """Combine terms with OR.
+        There must be a term added before using this method.
+
+        Arguments:
+            close_group (bool): If ``True``, will end the current group and start a new one.
+                    If ``False``, will continue current group.
+
+                    Example:
+
+                        If the current query is "(term1"
+                        .or(close_group=True) => "(term1) OR("
+                        .or(close_group=False) => "(term1 OR "
+
+        Returns:
+            SearchHelper: Self
+        """
+        if not self.initialized:
+            raise ValueError("You must add a search term before adding an operator.")
+        else:
+            self._operator("OR", close_group=close_group)
+        return self
+
+    def _negate(self):
+        """Negates the next added term with NOT.
+
+        Returns:
+            SearchHelper: Self
+        """
+        self._operator("NOT")
+        return self
+
+    def _add_sort(self, field, ascending=True):
+        """Sort the search results by a certain field.
+
+        If this method is called multiple times, the later sort fields are given lower priority,
+        and will only be considered when the eariler fields have the same value.
+
+        Arguments:
+            field (str): The field to sort by, in Elasticsearch dot syntax.
+            ascending (bool): Sort in ascending order? **Default**: ``True``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # Fields must be strings for Elasticsearch
+        field = str(field)
+        # No-op on blank sort field
+        if field:
+            self.__query["sort"].append({
+                'field_name': field,
+                'order': 'asc' if ascending else 'desc'
+            })
+        return self
+
+    def _ex_search(self, limit=None, info=False, retries=3):
+        """Execute a search and return the results, up to the ``SEARCH_LIMIT``.
+
+        Uses the query currently in this SearchHelper.
+
+        Arguments:
+            limit (int): Maximum number of entries to return. **Default**: ``10`` for basic
+                queries, and ``10000`` for advanced.
+            info (bool): If ``False``, search will return a list of the results.
+                    If ``True``, search will return a tuple containing the results list
+                    and other information about the query.
+                    **Default:** ``False``.
+            retries (int): The number of times to retry a Search query if it fails.
+                           **Default:** 3.
+
+        Returns:
+            If ``info`` is ``False``, *list*: The search results.
+            If ``info`` is ``True``, *tuple*: The search results,
+            and a dictionary of query information.
+        """
+        # Make sure there is query information present
+        if not self.initialized:
+            raise ValueError('No query has been set.')
+
+        # Create Search-ready query
+        if limit is not None:
+            self.__query["limit"] = limit
+        query = _validate_query(self.__query)
+
+        tries = 0
+        errors = []
+        while True:
+            # Try searching until success or `retries` number of failures
+            # Raise exception after `retries` failures
+            try:
+                search_res = self.__search_client.post_search(self.index, query)
+            except globus_sdk.SearchAPIError as e:
+                if tries >= retries:
+                    raise
+                else:
+                    errors.append(repr(e))
+            except Exception as e:
+                if tries >= retries:
+                    raise
+                else:
+                    errors.append(repr(e))
+            else:
+                break
+            tries += 1
+
+        # Remove the wrapping on each entry from Globus search
+        res = mdf_toolbox.gmeta_pop(search_res, info=info)
+
+        # Add more information to output if requested
+        if info:
+            # Add everything from the query itself
+            info_dict = mdf_toolbox.dict_merge(res[1], query)
+            # But rename "q" to "query" for clarity
+            info_dict["query"] = info_dict.pop("q")
+            # Add other useful/interesting parameters
+            info_dict["index_uuid"] = self.index
+            info_dict["retries"] = tries
+            info_dict["errors"] = errors
+            # Remake tuple because tuples don't suport assignment
+            res = (res[0], info_dict)
+        return res
+
+    def _mapping(self):
+        """Fetch the entire mapping for the specified index.
+
+        Returns:
+            dict: The full mapping for the index.
+        """
+        return (self.__search_client.get(
+                    "/unstable/index/{}/mapping".format(mdf_toolbox.translate_index(self.index)))
+                ["mappings"])
+
+    # ************************************************************************************
+    # * Query-building functions
+    # ************************************************************************************
+    # Note: Only match_term, match_field, exclude_field, and add_sort directly modify
+    #       the query. The other helpers use those core functions for advanced behavior.
+    # ************************************************************************************
+
+    def match_term(self, value, required=True, new_group=False):
+        """Add a fulltext search term to the query.
+
+        Warning:
+            Do not use this method with any other query-building helpers. This method
+            is only for building fulltext queries (in non-advanced mode). Using other
+            helpers, such as ``match_field()``, will cause the query to run in advanced mode.
+            If a fulltext term query is run in advanced mode, it will have unexpected
+            results.
+
+        Arguments:
+            value (str): The term to match.
+            required (bool): If ``True``, will add term with ``AND``.
+                    If ``False``, will use ``OR``. **Default:** ``True``.
+            new_group (bool): If ``True``, will separate the term into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # If not the start of the query string, add an AND or OR
+        if self.initialized:
+            if required:
+                self._and_join(new_group)
+            else:
+                self._or_join(new_group)
+        self._term(value)
+        return self
+
+    def match_field(self, field, value, required=True, new_group=False):
+        """Add a ``field:value`` term to the query.
+        Matches will have the ``value`` in the ``field``.
+
+        Arguments:
+            field (str): The field to check for the value.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            value (str): The value to match.
+            required (bool): If ``True``, will add term with ``AND``.
+                    If ``False``, will use ``OR``. **Default:** ``True``.
+            new_group (bool): If ``True``, will separate the term into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # If not the start of the query string, add an AND or OR
+        if self.initialized:
+            if required:
+                self._and_join(new_group)
+            else:
+                self._or_join(new_group)
+        self._field(field, value)
+        return self
+
+    def exclude_field(self, field, value, new_group=False):
+        """Exclude a ``field:value`` term from the query.
+        Matches will NOT have the ``value`` in the ``field``.
+
+        Arguments:
+            field (str): The field to check for the value.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            value (str): The value to exclude.
+            new_group (bool): If ``True``, will separate term the into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # No-op on missing arguments
+        if not field and not value:
+            return self
+        # If not the start of the query string, add an AND
+        # OR would not make much sense for excluding
+        if self.initialized:
+            self._and_join(new_group)
+        self._negate()._field(str(field), str(value))
+        return self
+
+    def match_exists(self, field, required=True, new_group=False):
+        """Require a field to exist in the results.
+        Matches will have some value in ``field``.
+
+        Arguments:
+            field (str): The field to check.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            required (bool): If ``True``, will add term with ``AND``.
+                    If ``False``, will use ``OR``. **Default:** ``True``.
+            new_group (bool): If ``True``, will separate the term into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        return self.match_field(field, "*", required=required, new_group=new_group)
+
+    def match_not_exists(self, field, new_group=False):
+        """Require a field to not exist in the results.
+        Matches will not have ``field`` present.
+
+        Arguments:
+            field (str): The field to check.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            new_group (bool): If ``True``, will separate the term into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        return self.exclude_field(field, "*", new_group=new_group)
+
+    def match_range(self, field, start=None, stop=None, inclusive=True,
+                    required=True, new_group=False):
+        """Add a ``field:[some range]`` term to the query.
+        Matches will have a ``value`` in the range in the ``field``.
+
+        Arguments:
+            field (str): The field to check for the value.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            start (str or int): The starting value, or ``None`` for no lower bound.
+                    **Default:** ``None``.
+            stop (str or int): The ending value, or ``None`` for no upper bound.
+                    **Default:** ``None``.
+            inclusive (bool): If ``True``, the ``start`` and ``stop`` values will be included
+                    in the search.
+                    If ``False``, the start and stop values will not be included
+                    in the search.
+                    **Default:** ``True``.
+            required (bool): If ``True``, will add term with ``AND``.
+                    If ``False``, will use ``OR``. **Default:** ``True``.
+            new_group (bool): If ``True``, will separate the term into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # Accept None as *
+        if start is None:
+            start = "*"
+        if stop is None:
+            stop = "*"
+        # *-* is the same as field exists
+        if start == "*" and stop == "*":
+            return self.match_exists(field, required=required, new_group=new_group)
+
+        if inclusive:
+            value = "[" + str(start) + " TO " + str(stop) + "]"
+        else:
+            value = "{" + str(start) + " TO " + str(stop) + "}"
+        return self.match_field(field, value, required=required, new_group=new_group)
+
+    def exclude_range(self, field, start="*", stop="*", inclusive=True, new_group=False):
+        """Exclude a ``field:[some range]`` term from the query.
+        Matches will not have any ``value`` in the range in the ``field``.
+
+        Arguments:
+            field (str): The field to check for the value.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            start (str or int): The starting value, or ``None`` for no lower bound.
+                    **Default:** ``None``.
+            stop (str or int): The ending value, or ``None`` for no upper bound.
+                    **Default:** ``None``.
+            inclusive (bool): If ``True``, the ``start`` and ``stop`` values will be excluded
+                    from the search.
+                    If ``False``, the ``start`` and ``stop`` values will not be excluded
+                    from the search.
+                    **Default:** ``True``.
+            new_group (bool): If ``True``, will separate the term into a new parenthetical group.
+                    If ``False``, will not.
+                    **Default:** ``False``.
+
+        Returns:
+            SearchHelper: Self
+        """
+        # Accept None as *
+        if start is None:
+            start = "*"
+        if stop is None:
+            stop = "*"
+        # *-* is the same as field doesn't exist
+        if start == "*" and stop == "*":
+            return self.match_not_exists(field, new_group=new_group)
+
+        if inclusive:
+            value = "[" + str(start) + " TO " + str(stop) + "]"
+        else:
+            value = "{" + str(start) + " TO " + str(stop) + "}"
+        return self.exclude_field(field, value, new_group=new_group)
+
+    def exclusive_match(self, field, value):
+        """Match exactly the given value(s), with no other data in the field.
+
+        Arguments:
+            field (str): The field to check for the value.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            value (str or list of str): The value(s) to match exactly.
+
+        Returns:
+            SearchHelper: Self
+        """
+        if isinstance(value, str):
+            value = [value]
+
+        # Hacky way to get ES to do exclusive search
+        # Essentially have a big range search that matches NOT anything
+        # Except for the actual values
+        # Example: [foo, bar, baz] =>
+        #   (NOT {* TO foo} AND [foo TO foo] AND NOT {foo to bar} AND [bar TO bar]
+        #    AND NOT {bar TO baz} AND [baz TO baz] AND NOT {baz TO *})
+        # Except it must be sorted to not overlap
+        value.sort()
+
+        # Start with removing everything before first value
+        self.exclude_range(field, "*", value[0], inclusive=False, new_group=True)
+        # Select first value
+        self.match_range(field, value[0], value[0])
+        # Do the rest of the values
+        for index, val in enumerate(value[1:]):
+            self.exclude_range(field, value[index-1], val, inclusive=False)
+            self.match_range(field, val, val)
+        # Add end
+        self.exclude_range(field, value[-1], "*", inclusive=False)
+        # Done
+        return self
+
+    def add_sort(self, field, ascending=True):
+        """Sort the search results by a certain field.
+
+        If this method is called multiple times, the later sort fields are given lower priority,
+        and will only be considered when the eariler fields have the same value.
+
+        Arguments:
+            field (str): The field to sort by.
+                    The field must be namespaced according to Elasticsearch rules
+                    using the dot syntax.
+                    For example, ``"mdf.source_name"`` is the ``source_name`` field
+                    of the ``mdf`` dictionary.
+            ascending (bool): If ``True``, the results will be sorted in ascending order.
+                    If ``False``, the results will be sorted in descending order.
+                    **Default**: ``True``.
+        Returns:
+            SearchHelper: Self
+        """
+        # No-op on blank field
+        if not field:
+            return self
+        self._add_sort(field, ascending=ascending)
+        return self
+
+    # ************************************************************************************
+    # * Execution functions
+    # ************************************************************************************
+
+    def search(self, q=None, advanced=False, limit=None, info=False, reset_query=True):
+        """Execute a search and return the results, up to the ``SEARCH_LIMIT``.
+
+        Arguments:
+            q (str): The query to execute. **Default:** The current helper-formed query, if any.
+                    There must be some query to execute.
+            advanced (bool): Whether to treat ``q`` as a basic or advanced query.
+                Has no effect if a query is not supplied in ``q``.
+                **Default:** ``False``
+            limit (int): The maximum number of results to return.
+                    The max for this argument is the ``SEARCH_LIMIT`` imposed by Globus Search.
+                    **Default:** ``SEARCH_LIMIT`` for advanced queries, 10 for basic queries.
+            info (bool): If ``False``, search will return a list of the results.
+                    If ``True``, search will return a tuple containing the results list
+                    and other information about the query.
+                    **Default:** ``False``.
+            reset_query (bool): If ``True``, will destroy the current query after execution
+                    and start a fresh one.
+                    If ``False``, will keep the current query set.
+                    Has no effect if a query is supplied in ``q``.
+                    **Default:** ``True``.
+
+        Returns:
+            If ``info`` is ``False``, *list*: The search results.
+            If ``info`` is ``True``, *tuple*: The search results,
+            and a dictionary of query information.
+
+        Note:
+            If a query is specified in ``q``, the current, helper-built query (if any)
+            will not be used in the search or modified.
+        """
+        # If q not specified, use internal, helper-built query
+        if q is None:
+            res = self._ex_search(info=info, limit=limit)
+            if reset_query:
+                self.reset_query()
+            return res
+        # If q was specified, run a totally independent query with a new SearchHelper
+        # Init SearchHelper with query, then call .search(), which will use it
+        # ._ex_search() not canonical way to perform single-statement search, so not used
+        # reset_query is False to skip the unnecessary query reset - SH not needed after search
+        else:
+            return SearchHelper(index=self.index, search_client=self.__search_client, q=q,
+                                advanced=advanced).search(info=info, limit=limit,
+                                                          reset_query=False)
+
+    # ************************************************************************************
+    # * Query utility functions
+    # ************************************************************************************
+
+    def show_fields(self, block=None):
+        """Retrieve and return the mapping for the given metadata block.
+
+        Arguments:
+            block (str): The top-level field to fetch the mapping for (for example, ``"mdf"``),
+                    or the special values ``None`` for everything or ``"top"`` for just the
+                    top-level fields.
+                    **Default:** ``None``.
+            index (str): The Search index to map. **Default:** The current index.
+
+        Returns:
+            dict: ``field:datatype`` pairs.
+        """
+        mapping = self._mapping()
+        if block is None:
+            return mapping
+        elif block == "top":
+            blocks = set()
+            for key in mapping.keys():
+                blocks.add(key.split(".")[0])
+            block_map = {}
+            for b in blocks:
+                block_map[b] = "object"
+        else:
+            block_map = {}
+            for key, value in mapping.items():
+                if key.startswith(block):
+                    block_map[key] = value
+        return block_map
+
+    def current_query(self):
+        """Return the current query string.
+
+        Returns:
+            str: The current query.
+        """
+        return self._clean_query()
+
+    def reset_query(self):
+        """Destroy the current query and create a fresh one.
+        This method should not be chained.
+
+        Returns:
+            None
+        """
+        self.__query = deepcopy(BLANK_QUERY)
+        return

--- a/mdf_toolbox/sub_helpers.py
+++ b/mdf_toolbox/sub_helpers.py
@@ -1,0 +1,140 @@
+import warnings
+
+from mdf_toolbox.search_helper import SearchHelper, SEARCH_LIMIT
+
+
+class AggregateHelper(SearchHelper):
+    """Subclass to add the ``aggregate()`` functionality to the SearchHelper.
+
+    ``aggregate()`` is currently the only way to retrieve more than 10,000 entries
+    from Globus Search, and requires a ``scroll_field`` index field.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Add the AggregateHelper to a SearchHelper.
+
+        Arguments:
+            scroll_field (str): The field on which to scroll. This should be a field
+                    that counts/indexes the entries.
+        """
+        self.scroll_field = kwargs.get("scroll_field", None)
+        super().__init__(*args, **kwargs)
+
+    def _aggregate(self, scroll_field, scroll_size=SEARCH_LIMIT):
+        """Perform an advanced query, and return *all* matching results.
+        Will automatically perform multiple queries in order to retrieve all results.
+
+        Note: All ``aggregate`` queries run in advanced mode.
+
+        Arguments:
+            scroll_field (str): The field on which to scroll. This should be a field
+                    that counts/indexes the entries.
+            scroll_size (int): Maximum number of records returned per query. Must be
+                    between one and the ``SEARCH_LIMIT`` (inclusive).
+                    **Default:** ``SEARCH_LIMIT``.
+
+        Returns:
+            list of dict: All matching entries.
+        """
+        # Make sure scroll_field is valid
+        if not scroll_field:
+            raise AttributeError("scroll_field is required.")
+
+        # Make sure the query is set
+        if not self.initialized:
+            raise AttributeError('No query has been set.')
+
+        # Warn the user if we are changing the setting of advanced
+        if not self._SearchHelper__query["advanced"]:
+            warnings.warn('This query will be run in advanced mode.', RuntimeWarning)
+            self._SearchHelper__query["advanced"] = True
+
+        # Inform the user if they set an invalid value for the query size
+        if scroll_size <= 0:
+            raise AttributeError('Scroll size must greater than zero')
+
+        # Get the total number of records
+        total = self.search(limit=0, info=True, reset_query=False)[1]["total_query_matches"]
+
+        # If aggregate is unnecessary, use Search automatically instead
+        if total <= SEARCH_LIMIT:
+            return self.search(limit=SEARCH_LIMIT, reset_query=False)
+
+        # Scroll until all results are found
+        output = []
+
+        scroll_pos = 0
+        while len(output) < total:
+
+            # Scroll until the width is small enough to get all records
+            #   `scroll_id`s are unique to each dataset. If multiple datasets
+            #   match a certain query, the total number of matching records
+            #   may exceed the maximum that search will return - even if the
+            #   scroll width is much smaller than that maximum
+            scroll_width = scroll_size
+            while True:
+                query = "({q}) AND ({field}:>={start} AND {field}:<{end})".format(
+                        q=self._SearchHelper__query["q"], field=scroll_field, start=scroll_pos,
+                        end=scroll_pos+scroll_width)
+
+                results, info = self.search(q=query, advanced=True, info=True)
+
+                # Check to make sure that all the matching records were returned
+                if info["total_query_matches"] <= len(results):
+                    break
+
+                # If not, reduce the scroll width
+                # new_width is proportional with the proportion of results returned
+                new_width = scroll_width * (len(results) // info["total_query_matches"])
+
+                # scroll_width should never be 0, and should only be 1 in rare circumstances
+                scroll_width = new_width if new_width > 1 else max(scroll_width//2, 1)
+
+            # Append the results to the output
+            output.extend(results)
+            scroll_pos += scroll_width
+
+        return output
+
+    def aggregate(self, q=None, scroll_size=SEARCH_LIMIT, reset_query=True, **kwargs):
+        """Perform an advanced query, and return *all* matching results.
+        Will automatically perform multiple queries in order to retrieve all results.
+
+        Note:
+            All ``aggregate`` queries run in advanced mode, and ``info`` is not available.
+
+        Arguments:
+            q (str): The query to execute. **Default:** The current helper-formed query, if any.
+                    There must be some query to execute.
+            scroll_size (int): Maximum number of records returned per query. Must be
+                    between one and the ``SEARCH_LIMIT`` (inclusive).
+                    **Default:** ``SEARCH_LIMIT``.
+            reset_query (bool): If ``True``, will destroy the current query after execution
+                    and start a fresh one.
+                    If ``False``, will keep the current query set.
+                    **Default:** ``True``.
+
+        Keyword Arguments:
+            scroll_field (str): The field on which to scroll. This should be a field
+                    that counts/indexes the entries.
+                    This should be set in ``self.scroll_field``, but if your application
+                    requires separate scroll fields for a single client,
+                    it can be set in this way as well.
+                    **Default**: ``self.scroll_field``.
+
+        Returns:
+            list of dict: All matching records.
+        """
+        scroll_field = kwargs.get("scroll_field", self.scroll_field)
+
+        # If q not specified, use internal, helper-built query
+        if q is None:
+            res = self._aggregate(scroll_field=scroll_field, scroll_size=scroll_size)
+            if reset_query:
+                self.reset_query()
+            return res
+        # Otherwise, run an independent query as SearchHelper.search() does.
+        else:
+            return self.__class__(index=self.index, q=q, advanced=True,
+                                  search_client=self._SearchHelper__search_client
+                                  ).aggregate(scroll_size=scroll_size, reset_query=reset_query)

--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -45,6 +45,7 @@ KNOWN_CLIENTS = {
 SEARCH_INDEX_UUIDS = {
     "mdf": "1a57bbe5-5272-477f-9d31-343b8258b7a5",
     "mdf-test": "5acded0c-a534-45af-84be-dcf042e36412",
+    "mdf-dev": "aeccc263-f083-45f5-ab1d-08ee702b3384",
     "dlhub": "847c9105-18a0-4ffb-8a71-03dd76dfcc9d",
     "dlhub-test": "5c89e0a9-00e5-4171-b415-814fe4d0b8af"
 }

--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -1,6 +1,7 @@
 from collections.abc import Container, Iterable, Mapping
 from copy import deepcopy
 from datetime import datetime
+import errno
 import json
 import os
 import shutil
@@ -387,6 +388,27 @@ def anonymous_login(services):
                   "Anonymous access may not be allowed.".format(serv))
 
     return clients
+
+
+def logout(token_dir=DEFAULT_CRED_PATH):
+    """Remove ALL tokens in the token directory.
+    This will force re-authentication to all services using a Toolbox login() function.
+
+    Arguments:
+        token_dir (str): The path to the directory to save tokens in and look for
+                credentials by default. If this argument was given to a login() function,
+                the same value must be given here to properly logout.
+                Default DEFAULT_CRED_PATH.
+    """
+    for f in os.listdir(token_dir):
+        if f.endswith("tokens.json"):
+            try:
+                os.remove(os.path.join(token_dir, f))
+            except OSError as e:
+                # Eat ENOENT (no such file/dir, tokens already deleted) only,
+                # raise any other issue (bad permissions, etc.)
+                if e.errno != errno.ENOENT:
+                    raise
 
 
 # *************************************************

--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -10,11 +10,6 @@ from globus_nexus_client import NexusClient
 import globus_sdk
 from globus_sdk.base import BaseClient
 from globus_sdk.response import GlobusHTTPResponse
-try:
-    from mdf_connect_client import MDFConnectClient
-except ImportError:
-    print("Proceeding without mdf_connect_client")
-    MDFConnectClient = None
 
 
 KNOWN_SCOPES = {
@@ -45,7 +40,6 @@ KNOWN_CLIENTS = {
     "search": globus_sdk.SearchClient,
     "search_ingest": globus_sdk.SearchClient,
     #  "publish": DataPublicationClient,  # Defined in this module, added to dict later
-    "mdf_connect": MDFConnectClient,
     "groups": NexusClient
 }
 SEARCH_INDEX_UUIDS = {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mdf_toolbox',
-    version='0.3.7',
+    version='0.3.8',
     packages=['mdf_toolbox'],
     description='Materials Data Facility Python utilities',
     long_description=("Toolbox is the Materials Data Facility Python package"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mdf_toolbox',
-    version='0.3.6',
+    version='0.3.7',
     packages=['mdf_toolbox'],
     description='Materials Data Facility Python utilities',
     long_description=("Toolbox is the Materials Data Facility Python package"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mdf_toolbox',
-    version='0.3.5',
+    version='0.3.6',
     packages=['mdf_toolbox'],
     description='Materials Data Facility Python utilities',
     long_description=("Toolbox is the Materials Data Facility Python package"

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name='mdf_toolbox',
-    version='0.3.8',
+    version='0.4.0',
     packages=['mdf_toolbox'],
     description='Materials Data Facility Python utilities',
     long_description=("Toolbox is the Materials Data Facility Python package"
                       " containing utility functions and other tools."),
     install_requires=[
         "globus_nexus_client>=0.2.8",
-        "globus-sdk>=1.5.0",
+        "globus-sdk>=1.7.0",
         "requests>=2.18.4"
     ],
     python_requires=">=3.4",

--- a/tests/test_search_helper.py
+++ b/tests/test_search_helper.py
@@ -1,0 +1,565 @@
+from copy import deepcopy
+import os
+import re
+import shutil
+
+from globus_sdk import SearchAPIError
+import pytest
+
+import mdf_toolbox
+from mdf_toolbox.search_helper import (SearchHelper, _validate_query,
+                                       BLANK_QUERY, SEARCH_LIMIT)
+
+# Manually logging in for SearchHelper testing
+CREDENTIALS = {
+    "app_name": "SearchHelper_Client",
+    "services": ["search"]
+}
+SEARCH_CLIENT = mdf_toolbox.login(credentials=CREDENTIALS)["search"]
+INDEX = "mdf"
+
+# For purely historical reasons, internal-function tests create a SearchHelper
+# called "q" while external-function tests use "f". This was a meaningful distinction
+# when internal functions were in Query and external in Forge, but is not now.
+
+
+# ***********************************************
+# * Static functions
+# ***********************************************
+
+# _clean_query_string() effectively tested in test_clean_query()
+
+def test_validate_query():
+    # Error on no query
+    with pytest.raises(ValueError):
+        _validate_query(deepcopy(BLANK_QUERY))
+
+    # If all fields set correctly, no changes
+    query1 = deepcopy(BLANK_QUERY)
+    query1["q"] = "(mdf.source_name:oqmd)"
+    query1["advanced"] = True
+    query1["limit"] = 1234
+    query1["offset"] = 5
+    query1["facets"] = "GFacet document"
+    query1["filters"] = "GFilter document"
+    query1["sort"] = "GSort document"
+    res1 = _validate_query(query1)
+    assert query1 == res1
+    assert query1 is not res1
+
+    query2 = deepcopy(BLANK_QUERY)
+    # q and limit get corrected
+    query2["q"] = "(mdf.source_name:oqmd("
+    query2["limit"] = 20000
+    # None for offset is invalid normally, but should not be removed
+    # because it is not the default value - the user has set it
+    query2["offset"] = None
+    # No errors on missing data
+    query2.pop("filters")
+    # Unsupported fields get removed
+    query2["badfield"] = "yes"
+    res2 = _validate_query(query2)
+    # Default values get removed
+    assert res2 == {
+        "q": "(mdf.source_name:oqmd)",
+        "limit": SEARCH_LIMIT,
+        "offset": None
+    }
+
+
+# ***********************************************
+# * Internals
+# ***********************************************
+
+def test_init():
+    q1 = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    assert q1._SearchHelper__query["q"] == "("
+    assert q1._SearchHelper__query["advanced"] is False
+    assert q1.initialized is False
+
+    q2 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="mdf.source_name:oqmd", advanced=True)
+    assert q2._SearchHelper__query["q"] == "mdf.source_name:oqmd"
+    assert q2._SearchHelper__query["advanced"] is True
+    assert q2.initialized is True
+
+    # Test without explicit SearchClient
+    q3 = SearchHelper(INDEX)
+    assert q3._SearchHelper__query["advanced"] is False
+    assert q3.initialized is False
+
+
+def test_term():
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Single match test
+    assert isinstance(q._term("term1"), SearchHelper)
+    assert q._SearchHelper__query["q"] == "(term1"
+    assert q.initialized is True
+    # Multi-match test
+    q._and_join()._term("term2")
+    assert q._SearchHelper__query["q"] == "(term1 AND term2"
+    # Grouping test
+    q._or_join(close_group=True)._term("term3")
+    assert q._SearchHelper__query["q"] == "(term1 AND term2) OR (term3"
+
+
+def test_field():
+    q1 = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Single field and return value test
+    assert isinstance(q1._field("mdf.source_name", "oqmd"), SearchHelper)
+    assert q1._SearchHelper__query["q"] == "(mdf.source_name:oqmd"
+    # Multi-field and grouping test
+    q1._and_join(close_group=True)._field("dc.title", "sample")
+    assert q1._SearchHelper__query["q"] == "(mdf.source_name:oqmd) AND (dc.title:sample"
+    # Negation test
+    q1._negate()
+    assert q1._SearchHelper__query["q"] == "(mdf.source_name:oqmd) AND (dc.title:sample NOT "
+    # Explicit operator test
+    # Makes invalid query for this case
+    q1._operator("NOT")
+    assert q1._SearchHelper__query["q"] == "(mdf.source_name:oqmd) AND (dc.title:sample NOT  NOT "
+    # Ensure advanced is set
+    assert q1._SearchHelper__query["advanced"] is True
+
+    # Test noop on blanks
+    q2 = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    assert q2._SearchHelper__query["q"] == "("
+    q2._field(field="", value="value")
+    assert q2._SearchHelper__query["q"] == "("
+    q2._field(field="field", value="")
+    assert q2._SearchHelper__query["q"] == "("
+    q2._field(field="", value="")
+    assert q2._SearchHelper__query["q"] == "("
+    q2._field(field="field", value="value")
+    assert q2._SearchHelper__query["q"] == "(field:value"
+
+    # Test auto-quote
+    q3 = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    q3._field("dc.descriptions.description", "With Spaces")
+    assert q3._SearchHelper__query["q"] == '(dc.descriptions.description:"With Spaces"'
+    q3._and_join(close_group=True)._field("dc.title", "Mark's")
+    assert q3._SearchHelper__query["q"] == ('(dc.descriptions.description:"With Spaces") AND ('
+                                            'dc.title:"Mark\'s"')
+    q3._or_join(close_group=False)._field("dc.title", "The\nLarch")
+    assert q3._SearchHelper__query["q"] == ('(dc.descriptions.description:"With Spaces") AND ('
+                                            'dc.title:"Mark\'s" OR dc.title:"The\nLarch"')
+    # No auto-quote on ranges
+    q3._and_join(close_group=True)._field("block.range", "[5 TO 6]")
+    assert q3._SearchHelper__query["q"] == ('(dc.descriptions.description:"With Spaces") AND ('
+                                            'dc.title:"Mark\'s" OR dc.title:"The\nLarch") AND ('
+                                            'block.range:[5 TO 6]')
+
+
+def test_operator():
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    assert q._SearchHelper__query["q"] == "("
+    # Add bad operator
+    with pytest.raises(ValueError):
+        assert q._operator("FOO") == q
+    assert q._SearchHelper__query["q"] == "("
+    # Test operator cleaning
+    q._operator("   and ")
+    assert q._SearchHelper__query["q"] == "( AND "
+    # Test close_group
+    q._operator("OR", close_group=True)
+    assert q._SearchHelper__query["q"] == "( AND ) OR ("
+
+
+def test_and_join(capsys):
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Test not initialized
+    with pytest.raises(ValueError) as excinfo:
+        q._and_join()
+    assert 'before adding an operator' in str(excinfo.value)
+
+    # Regular join
+    q._term("foo")._and_join()
+    assert q._SearchHelper__query["q"] == "(foo AND "
+    # close_group
+    q._term("bar")._and_join(close_group=True)
+    assert q._SearchHelper__query["q"] == "(foo AND bar) AND ("
+
+
+def test_or_join(capsys):
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Test not initialized
+    with pytest.raises(ValueError) as excinfo:
+        q._or_join()
+    assert 'before adding an operator' in str(excinfo.value)
+
+    # Regular join
+    q._term("foo")._or_join()
+    assert q._SearchHelper__query["q"] == "(foo OR "
+
+    # close_group
+    q._term("bar")._or_join(close_group=True)
+    assert q._SearchHelper__query["q"] == "(foo OR bar) OR ("
+
+
+def test_ex_search():
+    # Error on no query
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    with pytest.raises(ValueError):
+        q._ex_search()
+
+    # Return info if requested
+    res2 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="Al")._ex_search(info=False)
+    assert isinstance(res2, list)
+    assert isinstance(res2[0], dict)
+    res3 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="Al")._ex_search(info=True)
+    assert isinstance(res3, tuple)
+    assert isinstance(res3[0], list)
+    assert isinstance(res3[0][0], dict)
+    assert isinstance(res3[1], dict)
+
+    # Check limit
+    res4 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="Al")._ex_search(info=False,
+                                                                               limit=3)
+    assert len(res4) == 3
+
+    # Check default limits
+    res5 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="Al")._ex_search()
+    assert len(res5) == 10
+    res6 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="mdf.source_name:nist_xps_db",
+                        advanced=True)._ex_search()
+    assert len(res6) == 10000
+
+    # Check limit correction (should throw a warning)
+    with pytest.warns(RuntimeWarning):
+        res7 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, advanced=True,
+                            q="mdf.source_name:nist_xps_db")._ex_search(limit=20000)
+    assert len(res7) == 10000
+
+    # Test index translation
+    # mdf = 1a57bbe5-5272-477f-9d31-343b8258b7a5
+    res8 = SearchHelper(INDEX, search_client=SEARCH_CLIENT,
+                        q="data")._ex_search(info=True, limit=1)
+    assert len(res8[0]) == 1
+    assert res8[1]["index_uuid"] == "1a57bbe5-5272-477f-9d31-343b8258b7a5"
+    with pytest.raises(SearchAPIError):
+        SearchHelper("notexists", search_client=SEARCH_CLIENT,
+                     q="data")._ex_search(info=True, limit=1)
+
+
+def test_chaining():
+    # Internal
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    q._field("source_name", "cip")
+    q._and_join()
+    q._field("elements", "Al")
+    res1 = q._ex_search(limit=10000)
+    res2 = (SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+            ._field("source_name", "cip")
+            ._and_join()
+            ._field("elements", "Al")
+            ._ex_search(limit=10000))
+    assert all([r in res2 for r in res1]) and all([r in res1 for r in res2])
+
+    # External
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    f.match_field("source_name", "cip")
+    f.match_field("material.elements", "Al")
+    res1 = f.search()
+    res2 = f.match_field("source_name", "cip").match_field("material.elements", "Al").search()
+    assert all([r in res2 for r in res1]) and all([r in res1 for r in res2])
+
+
+def test_clean_query():
+    # Effectively also tests _clean_query_string()
+    # Imbalanced/improper parentheses
+    q1 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="() term ")
+    assert q1._clean_query() == "term"
+    q2 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="(term)(")
+    assert q2._clean_query() == "(term)"
+    q3 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="(term) AND (")
+    assert q3._clean_query() == "(term)"
+    q4 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="(term AND term2")
+    assert q4._clean_query() == "(term AND term2)"
+    q5 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="term AND term2)")
+    assert q5._clean_query() == "(term AND term2)"
+    q6 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="((((term AND term2")
+    assert q6._clean_query() == "((((term AND term2))))"
+    q7 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="term AND term2))))")
+    assert q7._clean_query() == "((((term AND term2))))"
+
+    # Correct trailing operators
+    q8 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="term AND NOT term2 OR")
+    assert q8._clean_query() == "term AND NOT term2"
+    q9 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="term OR NOT term2 AND")
+    assert q9._clean_query() == "term OR NOT term2"
+    q10 = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="term OR term2 NOT")
+    assert q10._clean_query() == "term OR term2"
+
+
+def test_add_sort_internal():
+    # Sort ascending by atomic number
+    q = SearchHelper(INDEX, search_client=SEARCH_CLIENT, q="mdf.source_name:oqmd", advanced=True)
+    q._add_sort('crystal_structure.number_of_atoms', True)
+    res = q._ex_search(limit=1)
+    assert res[0]['crystal_structure']['number_of_atoms'] == 1
+
+    # Sort descending by composition
+    q._add_sort('material.composition', False)
+    res = q._ex_search(limit=1)
+    assert res[0]['crystal_structure']['number_of_atoms'] == 1
+    assert res[0]['material']['composition'].startswith('Zr')
+
+
+# ***********************************************
+# * Externals/user-facing
+# ***********************************************
+
+# Helper
+# Return codes:
+#  -1: No match, the value was never found
+#   0: Exclusive match, no values other than argument found
+#   1: Inclusive match, some values other than argument found
+#   2: Partial match, value is found in some but not all results
+def check_field(res, field, regex):
+    dict_path = ""
+    for key in field.split("."):
+        if key == "[]":
+            dict_path += "[0]"
+        else:
+            dict_path += ".get('{}', {})".format(key, "{}")
+    # If no results, set matches to false
+    all_match = (len(res) > 0)
+    only_match = (len(res) > 0)
+    some_match = False
+    for r in res:
+        vals = eval("r"+dict_path)
+        if vals == {}:
+            vals = []
+        elif type(vals) is not list:
+            vals = [vals]
+        # If a result does not contain the value, no match
+        if regex not in vals and not any([re.search(str(regex), value) for value in vals]):
+            all_match = False
+            only_match = False
+        # If a result contains other values, inclusive match
+        elif len(vals) != 1:
+            only_match = False
+            some_match = True
+        else:
+            some_match = True
+
+    if only_match:
+        # Exclusive match
+        return 0
+    elif all_match:
+        # Inclusive match
+        return 1
+    elif some_match:
+        # Partial match
+        return 2
+    else:
+        # No match
+        return -1
+
+
+def test_logout():
+    # Credentials should exist
+    assert os.path.exists(os.path.join(mdf_toolbox.DEFAULT_CRED_PATH,
+                                       CREDENTIALS["app_name"]+"_tokens.json"))
+    # Copy credentials out
+    shutil.copytree(mdf_toolbox.DEFAULT_CRED_PATH, "temp_tokens")
+
+    try:
+        mdf_toolbox.logout()
+        assert not os.path.exists(os.path.join(mdf_toolbox.DEFAULT_CRED_PATH,
+                                               CREDENTIALS["app_name"]+"_tokens.json"))
+    # Always reset credentials
+    finally:
+        # Must delete token dir so copytree will copy correctly
+        shutil.rmtree(mdf_toolbox.DEFAULT_CRED_PATH)
+        shutil.copytree("temp_tokens", mdf_toolbox.DEFAULT_CRED_PATH)
+        shutil.rmtree("temp_tokens")
+
+
+def test_match_field():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+
+    # Basic usage
+    f.match_field("mdf.source_name", "khazana_vasp")
+    res1 = f.search()
+    assert check_field(res1, "mdf.source_name", "khazana_vasp") == 0
+
+    # Check that query clears
+    assert f.current_query() == ""
+
+    # Also checking check_field and no-op
+    f.match_field("material.elements", "Al")
+    f.match_field("", "")
+    res2 = f.search()  # Enough so that we'd find at least 1 non-Al example
+    assert check_field(res2, "material.elements", "Al") == 1
+
+
+def test_exclude_field():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Basic usage
+    f.exclude_field("material.elements", "Al")
+    f.exclude_field("", "")
+    f.match_field("mdf.source_name", "ab_initio_solute_database")
+    f.match_field("mdf.resource_type", "record")
+    res1 = f.search()
+    assert check_field(res1, "material.elements", "Al") == -1
+
+
+def test_add_sort_external():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Sort ascending by atomic number
+    f.match_field("mdf.source_name", "oqmd")
+    f.add_sort('crystal_structure.number_of_atoms', True)
+    res = f.search(limit=1, reset_query=False)
+    assert res[0]['crystal_structure']['number_of_atoms'] == 1
+
+    # Sort descending by composition, with multi-sort
+    f.add_sort('material.composition', False)
+    res = f.search(limit=1)
+    assert res[0]['crystal_structure']['number_of_atoms'] == 1
+    assert res[0]['material']['composition'].startswith('Zr')
+
+
+def test_match_exists():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Basic usage
+    f.match_exists("services.citrine")
+    assert check_field(f.search(), "services.citrine", ".*") == 0
+
+
+def test_match_not_exists():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Basic usage
+    f.match_not_exists("services.citrine")
+    assert check_field(f.search(), "services.citrine", ".*") == -1
+
+
+def test_match_range():
+    # Single-value use
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    f.match_range("material.elements", "Al", "Al")
+    res1, info1 = f.search(info=True)
+    assert check_field(res1, "material.elements", "Al") == 1
+
+    res2, info2 = f.search("material.elements:Al", advanced=True, info=True)
+    assert info1["total_query_matches"] == info2["total_query_matches"]
+
+    # Non-matching use, test inclusive
+    f.match_range("material.elements", "Al", "Al", inclusive=False)
+    assert f.search() == []
+
+    # Actual range
+    f.match_range("material.elements", "Al", "Cu")
+    res4, info4 = f.search(info=True)
+    assert info1["total_query_matches"] < info4["total_query_matches"]
+    assert (check_field(res4, "material.elements", "Al") >= 0 or
+            check_field(res4, "material.elements", "Cu") >= 0)
+
+    # Nothing to match
+    assert f.match_range("field", start=None, stop=None) == f
+
+
+def test_exclude_range():
+    # Single-value use
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    f.exclude_range("material.elements", "Am", "*")
+    f.exclude_range("material.elements", "*", "Ak")
+    f.match_field("material.elements", "*")
+    res1, info1 = f.search(info=True)
+    assert (check_field(res1, "material.elements", "Al") == 0 or
+            check_field(res1, "material.elements", "Al") == 2)
+
+    res2, info2 = f.search("material.elements:Al", advanced=True, info=True)
+    assert info1["total_query_matches"] <= info2["total_query_matches"]
+
+    # Non-matching use, test inclusive
+    f.exclude_range("material.elements", "Am", "*")
+    f.exclude_range("material.elements", "*", "Ak")
+    f.exclude_range("material.elements", "Al", "Al", inclusive=False)
+    f.match_field("material.elements", "*")
+    res3, info3 = f.search(info=True)
+    assert info1["total_query_matches"] == info3["total_query_matches"]
+
+    # Nothing to match
+    assert f.exclude_range("field", start=None, stop=None) == f
+
+
+def test_exclusive_match():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    f.exclusive_match("material.elements", "Al")
+    res1 = f.search()
+    assert check_field(res1, "material.elements", "Al") == 0
+
+    f.exclusive_match("material.elements", ["Al", "Cu"])
+    res2 = f.search()
+    assert check_field(res2, "material.elements", "Al") == 1
+    assert check_field(res2, "material.elements", "Cu") == 1
+    assert check_field(res2, "material.elements", "Cp") == -1
+    assert check_field(res2, "material.elements", "Fe") == -1
+
+
+def test_search(capsys):
+    # Error on no query
+    with pytest.raises(ValueError):
+        f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+        f.search()
+
+    # Return info if requested
+    res2 = f.search("Al", info=False)
+    assert isinstance(res2, list)
+    assert isinstance(res2[0], dict)
+
+    res3 = f.search("Al", info=True)
+    assert isinstance(res3, tuple)
+    assert isinstance(res3[0], list)
+    assert isinstance(res3[0][0], dict)
+    assert isinstance(res3[1], dict)
+
+    # Check limit
+    res4 = f.match_term("Al").search(limit=3)
+    assert len(res4) == 3
+
+    # Check reset_query
+    f.match_field("mdf.source_name", "ta_melting")
+    res5 = f.search(reset_query=False)
+    res6 = f.search()
+    assert all([r in res6 for r in res5]) and all([r in res5 for r in res6])
+
+    # Check default index
+    f2 = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    assert (f2.match_term("data").search(limit=1, info=True)[1]["index_uuid"] ==
+            mdf_toolbox.translate_index(INDEX))
+
+
+def test_reset_query():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Term will return results
+    f.match_field("material.elements", "Al")
+    f.reset_query()
+
+    # Specifying no query will raise an error
+    with pytest.raises(ValueError):
+        assert f.search() == []
+
+
+def test_current_query():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    # Query.clean_query() is already tested, just need to check basic functionality
+    f.match_field("field", "value")
+    assert f.current_query() == "(field:value)"
+
+
+def test_show_fields():
+    f = SearchHelper(INDEX, search_client=SEARCH_CLIENT)
+    res1 = f.show_fields("top")
+    assert "mdf" in res1.keys()
+    res2 = f.show_fields(block="mdf")
+    assert "mdf.source_name" in res2.keys()
+    res3 = f.show_fields()
+    assert "dc.creators.creatorName" in res3.keys()
+
+
+def test_anonymous(capsys):
+    f = SearchHelper(INDEX, anonymous=True)
+    # Test search
+    assert len(f.search("mdf.source_name:ab_initio_solute_database",
+                        advanced=True, limit=300)) == 300

--- a/tests/test_sub_helpers.py
+++ b/tests/test_sub_helpers.py
@@ -1,0 +1,100 @@
+import pytest
+import re
+
+import mdf_toolbox
+
+
+SEARCH_CLIENT = mdf_toolbox.login(credentials={"app_name": "MDF_Forge",
+                                               "services": ["search"]})["search"]
+INDEX = "mdf"
+SCROLL_FIELD = "mdf.scroll_id"
+
+
+class DummyClient(mdf_toolbox.AggregateHelper, mdf_toolbox.SearchHelper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, scroll_field=SCROLL_FIELD, **kwargs)
+
+
+# Helper
+# Return codes:
+#  -1: No match, the value was never found
+#   0: Exclusive match, no values other than argument found
+#   1: Inclusive match, some values other than argument found
+#   2: Partial match, value is found in some but not all results
+def check_field(res, field, regex):
+    dict_path = ""
+    for key in field.split("."):
+        if key == "[]":
+            dict_path += "[0]"
+        else:
+            dict_path += ".get('{}', {})".format(key, "{}")
+    # If no results, set matches to false
+    all_match = (len(res) > 0)
+    only_match = (len(res) > 0)
+    some_match = False
+    for r in res:
+        vals = eval("r"+dict_path)
+        if vals == {}:
+            vals = []
+        elif type(vals) is not list:
+            vals = [vals]
+        # If a result does not contain the value, no match
+        if regex not in vals and not any([re.search(str(regex), value) for value in vals]):
+            all_match = False
+            only_match = False
+        # If a result contains other values, inclusive match
+        elif len(vals) != 1:
+            only_match = False
+            some_match = True
+        else:
+            some_match = True
+
+    if only_match:
+        # Exclusive match
+        return 0
+    elif all_match:
+        # Inclusive match
+        return 1
+    elif some_match:
+        # Partial match
+        return 2
+    else:
+        # No match
+        return -1
+
+
+def test_aggregate_internal(capsys):
+    q = DummyClient(index=INDEX, search_client=SEARCH_CLIENT, advanced=True)
+    # Error on no query
+    with pytest.raises(AttributeError):
+        q.aggregate()
+
+    # Basic aggregation
+    res1 = q.aggregate("mdf.source_name:nist_xps_db")
+    assert len(res1) > 10000
+    assert isinstance(res1[0], dict)
+
+    # Multi-dataset aggregation
+    q._SearchHelper__query["q"] = "(mdf.source_name:nist_xps_db OR mdf.source_name:khazana_vasp)"
+    res2 = q.aggregate()
+    assert len(res2) > 10000
+    assert len(res2) > len(res1)
+
+    # Unnecessary aggregation fallback to .search()
+    # Check success in Coveralls
+    q._SearchHelper__query["q"] = "mdf.source_name:khazana_vasp"
+    assert len(q.aggregate()) < 10000
+
+
+def test_aggregate_external():
+    # Test that aggregate uses the current query properly
+    # And returns results
+    # And respects the reset_query arg
+    f = DummyClient(INDEX, search_client=SEARCH_CLIENT)
+    f.match_field("mdf.source_name", "nist_xps_db")
+    res1 = f.aggregate(reset_query=False, index="mdf")
+    assert len(res1) > 10000
+    assert check_field(res1, "mdf.source_name", "nist_xps_db") == 0
+    res2 = f.aggregate()
+    assert len(res2) == len(res1)
+    assert check_field(res2, "mdf.source_name", "nist_xps_db") == 0

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -36,11 +36,6 @@ def test_login(capsys, monkeypatch):
     assert isinstance(res2.get("publish"), mdf_toolbox.DataPublicationClient)
     assert isinstance(res2.get("groups"), NexusClient)
 
-    creds3 = deepcopy(credentials)
-    creds3["services"] = "mdf_connect"
-    res3 = mdf_toolbox.login(creds3)
-    assert isinstance(res3.get("mdf_connect"), mdf_toolbox.MDFConnectClient)
-
     # Test fetching previous tokens
     creds = deepcopy(credentials)
     assert mdf_toolbox.login(creds).get("petrel_https_server")

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -106,6 +106,25 @@ def test_anonymous_login(capsys):
     assert "Error: No known client for 'invalid' service." in out
 
 
+def test_logout():
+    # Credentials should exist
+    assert os.path.exists(os.path.join(mdf_toolbox.DEFAULT_CRED_PATH,
+                                       credentials["app_name"]+"_tokens.json"))
+    # Copy credentials out
+    shutil.copytree(mdf_toolbox.DEFAULT_CRED_PATH, "temp_tokens")
+
+    try:
+        mdf_toolbox.logout()
+        assert not os.path.exists(os.path.join(mdf_toolbox.DEFAULT_CRED_PATH,
+                                               credentials["app_name"]+"_tokens.json"))
+    # Always reset credentials
+    finally:
+        # Must delete token dir so copytree will copy correctly
+        shutil.rmtree(mdf_toolbox.DEFAULT_CRED_PATH)
+        shutil.copytree("temp_tokens", mdf_toolbox.DEFAULT_CRED_PATH)
+        shutil.rmtree("temp_tokens")
+
+
 def test_uncompress_tree():
     root = os.path.join(os.path.dirname(__file__), "testing_files")
     # Basic test, should extract tar and nested tar, but not delete anything


### PR DESCRIPTION
This release brings in the generic SearchHelper class, which is made of code previously supporting Forge. SearchHelper is index-agnostic and combines the Query object from the Forge package and the core searching and query-building functions from Forge itself. The split is in support of other search clients, such as the DLHubClient, which can now use the index-agnostic SearchHelper functions without the unnecessary MDF-specific features of Forge. There are also several minor improvements to this functionality, including auto-quoting certain values.

Additionally, there is now an `mdf_toolbox.logout()` function.