### PR TITLE
Support for Windows endpoints in custom_transfer

### DIFF
--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -782,7 +782,7 @@ def get_local_ep(*args, **kwargs):
         warnings.warn("'get_local_ep()' has been deprecated in favor of "
                       "'globus_sdk.LocalGlobusConnectPersonal().endpoint_id'.")
     return globus_sdk.LocalGlobusConnectPersonal().endpoint_id
-    
+
 
 def posixify_path(path: str) -> str:
     """Ensure that a path is ready for use with Globus
@@ -797,13 +797,11 @@ def posixify_path(path: str) -> str:
     Returns:
         (str) Rectified path
     """
-
     is_windows = re.match('[A-Z]:\\\\', path) is not None
     if is_windows:
         ppath = PureWindowsPath(path)
         return '/{0}{1}'.format(ppath.drive[:1].lower(), ppath.as_posix()[2:])
     return path  # Nothing to do for POSIX paths
-
 
 
 # *************************************************

--- a/mdf_toolbox/toolbox.py
+++ b/mdf_toolbox/toolbox.py
@@ -521,7 +521,7 @@ def globus_check_directory(transfer_client, endpoint, path, allow_missing=False)
     try:
         transfer_client.operation_ls(endpoint, path=path)
         is_dir = True
-    except globus_sdk.exc.TransferAPIError as e:
+    except globus_sdk.TransferAPIError as e:
         # If error indicates path exists but is not dir, is not dir
         if e.code == "ExternalError.DirListingFailed.NotDirectory":
             is_dir = False
@@ -559,7 +559,7 @@ def globus_check_directory(transfer_client, endpoint, path, allow_missing=False)
                         exists = True
                         error = ("Path '{}' leads to a '{}', not a file or directory"
                                  .format(path, item_type))
-            except globus_sdk.exc.TransferAPIError as e:
+            except globus_sdk.TransferAPIError as e:
                 # Size limit means we can't figure out this path
                 if e.code == "ExternalError.DirListingFailed.SizeLimit":
                     error = ("Unable to check type of path '{}': Parent directory too large"

--- a/mdf_toolbox/version.py
+++ b/mdf_toolbox/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/mdf_toolbox/version.py
+++ b/mdf_toolbox/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -544,7 +544,7 @@ def test_translate_json():
     assert mdf_toolbox.translate_json(source_doc, mapping1, "na") == no_na_output
 
 
-def test_flatten_dict():
+def test_flatten_json():
     unflat_dict = {
         "key1": {
             "key2": {
@@ -555,7 +555,7 @@ def test_flatten_dict():
             },
             "key6": {
                 "key7": 555,
-                "key8": [1, {"key_not_flattened": "foo"}, "b"]
+                "key8": [1, {"list_flattened": "foo"}, "b"]
             }
         },
         "key9": "value3"
@@ -564,7 +564,8 @@ def test_flatten_dict():
         "key1.key2.key3.key4": "value1",
         "key1.key2.key5": "value2",
         "key1.key6.key7": 555,
-        "key1.key6.key8": [1, {"key_not_flattened": "foo"}, "b"],
+        "key1.key6.key8": [1, "b"],
+        "key1.key6.key8.list_flattened": "foo",
         "key9": "value3"
     }
-    assert mdf_toolbox.flatten_dict(unflat_dict) == flat_dict
+    assert mdf_toolbox.flatten_json(unflat_dict) == flat_dict


### PR DESCRIPTION
Fix for Windows-style paths being passed directly to TransferClients, which causes errors. Instead, they're now converted to POSIX-style paths.
Thanks @WardLT!