### PR TITLE
amend copying of 'data' object for globus-sdk v3

### DIFF
--- a/mdf_toolbox/globus_transfer.py
+++ b/mdf_toolbox/globus_transfer.py
@@ -104,7 +104,7 @@ def custom_transfer(transfer_client, source_ep, dest_ep, path_list, interval=DEF
             #   only the last (chronologically) error will be processed
             if event["is_error"] and event["time"] not in error_timestamps:
                 error_timestamps.add(event["time"])
-                ret_event = deepcopy(event.data)
+                ret_event = deepcopy(event)
                 # yield value should always have success: bool
                 ret_event["success"] = False
                 ret_event["finished"] = False


### PR DESCRIPTION
- the fix turned out to be simpler than expected -- if we just amend how the dict is being copied, all of the necessary functionality/logic is preserved
- using the `pagination` technique Stephen described made the items from `transfer_client.pagination.task_event_list(res["task_id"], items=100)` difficult to parse (the objects were very nested)
- keeping `transfer_client.task_event_list(res["task_id"])` instead meant we could still iterate through all of the events returned, but with less obfuscating structure