### PR TITLE
Relax pin for jsonschema

### DIFF
--- a/mdf_toolbox/version.py
+++ b/mdf_toolbox/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.6.0"
+__version__ = "0.6.1-alpha.1"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "globus_nexus_client>=0.4.1",
         "globus-sdk>=3.1.0",
         "requests>=2.26.0",
-        "jsonschema<=4.3.0"
+        "jsonschema>=4.3.0"
     ],
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
Toolbox was pinned to jsonschema <= 4.3.0  - this causes a unresolvable dependency with jupyter